### PR TITLE
Fix find_pte, disable ksan for now

### DIFF
--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -61,13 +61,13 @@ override KCFLAGS += \
     -nostdinc \
     -ffreestanding \
     -fno-stack-protector \
-    -fsanitize=kernel-address \
     -fno-stack-check \
     -fno-lto \
     -fno-PIC \
     -ffunction-sections \
     -fdata-sections \
     -fno-omit-frame-pointer \
+#    -fsanitize=kernel-address \
 
 # Internal C preprocessor flags that should not be changed by the user.
 override KCPPFLAGS := \


### PR DESCRIPTION
Disabled ksan for now. I haven't the time to see why, but with ksan enabled the stack overflows and starts clobbering the pml4 table and as a result a page fault occurs.